### PR TITLE
feature/block state refactor

### DIFF
--- a/src/main/java/com/github/nosrick/crockpot/CrockPotModClient.java
+++ b/src/main/java/com/github/nosrick/crockpot/CrockPotModClient.java
@@ -27,11 +27,14 @@ public class CrockPotModClient implements ClientModInitializer {
 
         ClientPlayNetworking.registerGlobalReceiver(CrockPotMod.CROCK_POT_CHANNEL, (client, handler, buf, responseSender) -> {
             BlockPos pos = buf.readBlockPos();
-            CrockPotBlockEntity.RedstoneOutputType outputType = buf.readEnumConstant(CrockPotBlockEntity.RedstoneOutputType.class);
-            BlockEntity blockEntity = client.world.getBlockEntity(pos);
+            NbtCompound nbt = buf.readNbt();
 
-            if(blockEntity instanceof CrockPotBlockEntity crockPotBlockEntity){
-                crockPotBlockEntity.setRedstoneOutputType(outputType);
+            if(nbt == null){
+                return;
+            }
+
+            if(client.world.getBlockEntity(pos) instanceof CrockPotBlockEntity crockPotBlockEntity){
+                crockPotBlockEntity.readNbt(nbt);
             }
         });
     }

--- a/src/main/java/com/github/nosrick/crockpot/block/CrockPotBlock.java
+++ b/src/main/java/com/github/nosrick/crockpot/block/CrockPotBlock.java
@@ -11,7 +11,6 @@ import net.minecraft.block.*;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityTicker;
 import net.minecraft.block.entity.BlockEntityType;
-import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.SidedInventory;
 import net.minecraft.item.*;

--- a/src/main/java/com/github/nosrick/crockpot/block/CrockPotBlock.java
+++ b/src/main/java/com/github/nosrick/crockpot/block/CrockPotBlock.java
@@ -42,6 +42,9 @@ public class CrockPotBlock extends BlockWithEntity implements InventoryProvider 
     public static final BooleanProperty NEEDS_SUPPORT = BooleanProperty.of("needs_support");
     public static final BooleanProperty HAS_LIQUID = BooleanProperty.of("has_liquid");
 
+    //THIS IS GROSS
+    public static final BooleanProperty UPDATE_ME = BooleanProperty.of("update_me");
+
     public CrockPotBlock() {
         super(FabricBlockSettings
                 .of(Material.METAL)
@@ -70,7 +73,7 @@ public class CrockPotBlock extends BlockWithEntity implements InventoryProvider 
     @Override
     protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
         super.appendProperties(builder);
-        builder.add(FACING, HAS_LIQUID, NEEDS_SUPPORT);
+        builder.add(FACING, HAS_LIQUID, NEEDS_SUPPORT, UPDATE_ME);
     }
 
     @Nullable
@@ -176,8 +179,8 @@ public class CrockPotBlock extends BlockWithEntity implements InventoryProvider 
 
         if (!potBlockEntity.isElectric()
                 && held.getItem() == Blocks.REDSTONE_BLOCK.asItem()) {
+            world.setBlockState(pos, state.with(UPDATE_ME, !state.get(UPDATE_ME)));
             potBlockEntity.setElectric(true);
-            world.setBlockState(pos, state.with(HAS_LIQUID, state.get(HAS_LIQUID)), Block.NOTIFY_ALL | Block.REDRAW_ON_MAIN_THREAD | Block.FORCE_STATE);
 
             if (!player.isCreative()) {
                 held.decrement(1);

--- a/src/main/java/com/github/nosrick/crockpot/client/colours/CrockPotBlockColourProvider.java
+++ b/src/main/java/com/github/nosrick/crockpot/client/colours/CrockPotBlockColourProvider.java
@@ -1,6 +1,5 @@
 package com.github.nosrick.crockpot.client.colours;
 
-import com.github.nosrick.crockpot.block.CrockPotBlock;
 import com.github.nosrick.crockpot.blockentity.CrockPotBlockEntity;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.color.block.BlockColorProvider;
@@ -23,14 +22,18 @@ public class CrockPotBlockColourProvider implements BlockColorProvider {
             return 0;
         }
 
+        if(!(world.getBlockEntity(pos) instanceof CrockPotBlockEntity potBlockEntity)){
+            return 0;
+        }
+
         if (tintIndex == 0) {
-            if (state.get(CrockPotBlock.ELECTRIC)) {
+            if (potBlockEntity.isElectric()) {
                 return ELECTRIC_COLOUR;
             }
 
             return POT_COLOUR;
         } else if (tintIndex == 1) {
-            if (state.get(CrockPotBlock.HAS_FOOD)) {
+            if (potBlockEntity.hasFood()) {
                 return FOOD_COLOUR;
             } else {
                 return WATER_COLOUR;

--- a/src/main/java/com/github/nosrick/crockpot/client/render/block/model/CrockPotBlockEntityRenderer.java
+++ b/src/main/java/com/github/nosrick/crockpot/client/render/block/model/CrockPotBlockEntityRenderer.java
@@ -47,15 +47,13 @@ public class CrockPotBlockEntityRenderer implements BlockEntityRenderer<CrockPot
             int light,
             int overlay) {
 
-        World world = entity.getWorld();
-
-        if (world == null || MinecraftClient.getInstance().isPaused()) {
+        if (!entity.hasFood()) {
             return;
         }
 
-        BlockState state = entity.getCachedState();
+        World world = entity.getWorld();
 
-        if (!state.get(CrockPotBlock.HAS_FOOD)) {
+        if (world == null || MinecraftClient.getInstance().isPaused()) {
             return;
         }
 
@@ -84,7 +82,7 @@ public class CrockPotBlockEntityRenderer implements BlockEntityRenderer<CrockPot
                     Quaternion.fromEulerXyzDegrees(rotation));
         }
 
-        int colour = entity.getCachedState().get(CrockPotBlock.ELECTRIC)
+        int colour = entity.isElectric()
                 ? CrockPotBlockColourProvider.ELECTRIC_COLOUR
                 : CrockPotBlockColourProvider.POT_COLOUR;
 
@@ -93,6 +91,7 @@ public class CrockPotBlockEntityRenderer implements BlockEntityRenderer<CrockPot
         g = ColorHelper.Argb.getGreen(colour) / 255f;
         b = ColorHelper.Argb.getBlue(colour) / 255f;
         a = ColorHelper.Argb.getAlpha(colour) / 255f;
+
         lidModel.render(
                 matrices,
                 vertexConsumers.getBuffer(RenderLayer.getEntitySolid(POT_LID_TEXTURE_ID)),


### PR DESCRIPTION
Re-writes the block states in CrockPotBlock.java a bit, so users will get less (hopefully zero!) warnings about models and block states and stuff.