### PR TITLE
feature/tags fill pots

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,19 +59,14 @@ dependencies {
         exclude module: 'modmenu'
     }
 
-    //Farmer's Delight
-    /*
-    modImplementation("curse.maven:farmers-delight-fabric-482834:${project.farmersdelight_version}") {
-        transitive = false
-    }
-    modRuntimeOnly("curse.maven:farmers-delight-fabric-482834:${project.farmersdelight_version}")
-    */
-
     //What the hell is that?
     modCompileOnly("mcp.mobius.waila:wthit-api:fabric-${project.wthit_version}") {
         transitive = false
     }
     modRuntimeOnly("mcp.mobius.waila:wthit:fabric-${project.wthit_version}")
+
+    //Early-Game Buckets
+    modCompileOnly("curse.maven:early-game-buckets-475470:${project.early_buckets_version}")
 
     //Cloth Config
     modApi("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_version}") {
@@ -80,6 +75,14 @@ dependencies {
 
     //ModMenu
     modImplementation("com.terraformersmc:modmenu:${project.modmenu_version}")
+
+    //Farmer's Delight
+    /*
+    modImplementation("curse.maven:farmers-delight-fabric-482834:${project.farmersdelight_version}") {
+        transitive = false
+    }
+    modRuntimeOnly("curse.maven:farmers-delight-fabric-482834:${project.farmersdelight_version}")
+    */
 
     //Not really required but useful for testing
     modRuntimeOnly("me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
     loader_version=0.14.6
 
 # Mod Properties
-	mod_version = 0.8.5
+	mod_version = 0.9.1
 	maven_group = com.github.nosrick
 	archives_base_name = crockpot
 	pretty_name = Crock Pot

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx1G
 	# check these on https://fabricmc.net/develop
     minecraft_version=1.18.2
     yarn_mappings=1.18.2+build.3
-    loader_version=0.13.3
+    loader_version=0.14.6
 
 # Mod Properties
 	mod_version = 0.8.5
@@ -14,7 +14,7 @@ org.gradle.jvmargs=-Xmx1G
 	pretty_name = Crock Pot
 
 # Dependencies
-    fabric_version=0.51.1+1.18.2
+    fabric_version=0.53.4+1.18.2
 
 #Optionals
 	rei_version=8.0.441
@@ -22,3 +22,4 @@ org.gradle.jvmargs=-Xmx1G
 	appleskin_version=mc1.18.2-2.4.0
 	cloth_version=6.2.57
 	modmenu_version=3.1.0
+	early_buckets_version=3785762

--- a/src/main/java/com/github/nosrick/crockpot/CrockPotMod.java
+++ b/src/main/java/com/github/nosrick/crockpot/CrockPotMod.java
@@ -1,6 +1,7 @@
 package com.github.nosrick.crockpot;
 
 import com.github.nosrick.crockpot.compat.cloth.ClothConfigManager;
+import com.github.nosrick.crockpot.compat.early_game_buckets.EarlyGameBucketsCompat;
 import com.github.nosrick.crockpot.registry.BlockRegistry;
 import com.github.nosrick.crockpot.registry.BlockEntityTypesRegistry;
 import com.github.nosrick.crockpot.registry.CrockPotSoundRegistry;
@@ -44,6 +45,10 @@ public class CrockPotMod implements ModInitializer {
 
         if(FabricLoader.getInstance().isModLoaded("cloth-config")){
             ClothConfigManager.registerAutoConfig();
+        }
+
+        if(FabricLoader.getInstance().isModLoaded("early_buckets")){
+            EarlyGameBucketsCompat.markAsLoaded();
         }
     }
 }

--- a/src/main/java/com/github/nosrick/crockpot/block/CrockPotBlock.java
+++ b/src/main/java/com/github/nosrick/crockpot/block/CrockPotBlock.java
@@ -211,9 +211,6 @@ public class CrockPotBlock extends BlockWithEntity implements InventoryProvider 
                     }
                 }
             }
-            else if(held.isIn(Tags.INFINITE_WATER_SOURCES_ITEMS)) {
-                //Just continue to do the thing
-            }
             else if (ConfigManager.canFillWithWaterBottle()
                     && heldItem instanceof PotionItem
                     && PotionUtil.getPotion(held) == Potions.WATER) {
@@ -221,7 +218,11 @@ public class CrockPotBlock extends BlockWithEntity implements InventoryProvider 
                     held.decrement(1);
                     player.giveItemStack(new ItemStack(Items.GLASS_BOTTLE));
                 }
-            } else {
+            }
+            else if(!held.isIn(Tags.INFINITE_WATER_SOURCES_ITEMS)) {
+                return ActionResult.FAIL;
+            }
+            else {
                 return ActionResult.FAIL;
             }
 

--- a/src/main/java/com/github/nosrick/crockpot/block/CrockPotBlock.java
+++ b/src/main/java/com/github/nosrick/crockpot/block/CrockPotBlock.java
@@ -1,6 +1,7 @@
 package com.github.nosrick.crockpot.block;
 
 import com.github.nosrick.crockpot.blockentity.CrockPotBlockEntity;
+import com.github.nosrick.crockpot.compat.early_game_buckets.EarlyGameBucketsCompat;
 import com.github.nosrick.crockpot.config.ConfigManager;
 import com.github.nosrick.crockpot.tag.Tags;
 import com.github.nosrick.crockpot.registry.BlockEntityTypesRegistry;
@@ -193,12 +194,27 @@ public class CrockPotBlock extends BlockWithEntity implements InventoryProvider 
         if (!state.get(HAS_LIQUID)) {
             Item heldItem = held.getItem();
 
-            if (heldItem == Items.WATER_BUCKET) {
+            if (held.isIn(Tags.CONSUMABLE_WATER_SOURCES_ITEMS)) {
                 if (!player.isCreative()) {
-                    held.decrement(1);
-                    player.giveItemStack(new ItemStack(Items.BUCKET));
+                    if(EarlyGameBucketsCompat.isLoaded()
+                        && EarlyGameBucketsCompat.isEarlyGameBucket(held))
+                    {
+                        ItemStack emptyContainer = EarlyGameBucketsCompat.getEmptyItem(held, player);
+                        held.decrement(1);
+                        player.giveItemStack(emptyContainer);
+                    }
+                    else if(heldItem instanceof BucketItem)
+                    {
+                        ItemStack emptyContainer = BucketItem.getEmptiedStack(held, player);
+                        held.decrement(1);
+                        player.giveItemStack(emptyContainer);
+                    }
                 }
-            } else if (ConfigManager.canFillWithWaterBottle()
+            }
+            else if(held.isIn(Tags.INFINITE_WATER_SOURCES_ITEMS)) {
+                //Just continue to do the thing
+            }
+            else if (ConfigManager.canFillWithWaterBottle()
                     && heldItem instanceof PotionItem
                     && PotionUtil.getPotion(held) == Potions.WATER) {
                 if (!player.isCreative()) {

--- a/src/main/java/com/github/nosrick/crockpot/compat/early_game_buckets/EarlyGameBucketsCompat.java
+++ b/src/main/java/com/github/nosrick/crockpot/compat/early_game_buckets/EarlyGameBucketsCompat.java
@@ -1,0 +1,34 @@
+package com.github.nosrick.crockpot.compat.early_game_buckets;
+
+import dev.satyrn.early_buckets.item.Bucket;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+
+public class EarlyGameBucketsCompat {
+
+    protected static boolean Loaded = false;
+
+    public static boolean isLoaded()
+    {
+        return Loaded;
+    }
+
+    public static void markAsLoaded(){
+        Loaded = true;
+    }
+
+    public static boolean isEarlyGameBucket(ItemStack probableBucket)
+    {
+        return probableBucket.getItem() instanceof Bucket;
+    }
+
+    public static ItemStack getEmptyItem(ItemStack probableBucket, PlayerEntity player)
+    {
+        if(probableBucket.getItem() instanceof Bucket bucket)
+        {
+            return bucket.getEmptyItemStack(probableBucket, player );
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/github/nosrick/crockpot/tag/Tags.java
+++ b/src/main/java/com/github/nosrick/crockpot/tag/Tags.java
@@ -15,6 +15,11 @@ public class Tags {
     public static TagKey<Block> CROCK_POT_REQUIRES_SUPPORT = createBlockTag(
             new Identifier(CrockPotMod.MOD_ID, "crock_pot_requires_support"));
 
+    public static TagKey<Item> CONSUMABLE_WATER_SOURCES_ITEMS = createItemTag(new Identifier(CrockPotMod.MOD_ID, "consumable_water_sources"));
+    public static TagKey<Block> CONSUMABLE_WATER_SOURCES_BLOCKS = createBlockTag(new Identifier(CrockPotMod.MOD_ID, "consumable_water_sources"));
+    public static TagKey<Item> INFINITE_WATER_SOURCES_ITEMS = createItemTag(new Identifier(CrockPotMod.MOD_ID, "infinite_water_sources"));
+    public static TagKey<Block> INFINITE_WATER_SOURCES_BLOCKS = createBlockTag(new Identifier(CrockPotMod.MOD_ID, "infinite_water_sources"));
+
     private static TagKey<Block> createBlockTag(Identifier id) {
         return TagKey.of(Registry.BLOCK_KEY, id);
     }

--- a/src/main/resources/data/crockpot/tags/blocks/consumable_water_sources.json
+++ b/src/main/resources/data/crockpot/tags/blocks/consumable_water_sources.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:snow",
+    "#minecraft:ice"
+  ]
+}

--- a/src/main/resources/data/crockpot/tags/blocks/infinite_water_sources.json
+++ b/src/main/resources/data/crockpot/tags/blocks/infinite_water_sources.json
@@ -1,0 +1,4 @@
+{
+  "replace": false,
+  "values": []
+}

--- a/src/main/resources/data/crockpot/tags/items/consumable_water_sources.json
+++ b/src/main/resources/data/crockpot/tags/items/consumable_water_sources.json
@@ -1,0 +1,19 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:water_bucket",
+    "minecraft:powder_snow_bucket",
+    {
+      "id": "early_buckets:wooden_water_bucket",
+      "required": false
+    },
+    {
+      "id": "early_buckets:clay_water_bucket",
+      "required": false
+    },
+    {
+      "id": "early_buckets:ceramic_water_bucket",
+      "required": false
+    }
+  ]
+}

--- a/src/main/resources/data/crockpot/tags/items/infinite_water_sources.json
+++ b/src/main/resources/data/crockpot/tags/items/infinite_water_sources.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:heart_of_the_sea"
+  ]
+}


### PR DESCRIPTION
Adds Early-Game Buckets compatibility!

Tags added for items that can fill the pot.
There are infinite and consumable item tags.
Infinite tagged items will not decrement or be used up in any way when filling the pot.
Consumable tagged items will try to empty the container, assuming it is a vanilla Minecraft bucket or an Early-Game Buckets bucket.